### PR TITLE
Add CRUD operations for taxes table

### DIFF
--- a/Sources/App/Controllers/TaxesController.swift
+++ b/Sources/App/Controllers/TaxesController.swift
@@ -1,0 +1,51 @@
+import Vapor
+import Fluent
+
+final class TaxesController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        let taxes = routes.grouped("taxes")
+        taxes.get(use: index)
+        taxes.post(use: create)
+        taxes.group(":taxID") { tax in
+            tax.get(use: show)
+            tax.put(use: update)
+            tax.delete(use: delete)
+        }
+    }
+
+    func index(req: Request) async throws -> [Tax] {
+        try await Tax.query(on: req.db).all()
+    }
+
+    func create(req: Request) async throws -> Tax {
+        let tax = try req.content.decode(Tax.self)
+        try await tax.save(on: req.db)
+        return tax
+    }
+
+    func show(req: Request) async throws -> Tax {
+        guard let tax = try await Tax.find(req.parameters.get("taxID"), on: req.db) else {
+            throw Abort(.notFound)
+        }
+        return tax
+    }
+
+    func update(req: Request) async throws -> HTTPStatus {
+        let updatedTax = try req.content.decode(Tax.self)
+        guard let tax = try await Tax.find(req.parameters.get("taxID"), on: req.db) else {
+            throw Abort(.notFound)
+        }
+        tax.name = updatedTax.name
+        tax.rate = updatedTax.rate
+        try await tax.save(on: req.db)
+        return .ok
+    }
+
+    func delete(req: Request) async throws -> HTTPStatus {
+        guard let tax = try await Tax.find(req.parameters.get("taxID"), on: req.db) else {
+            throw Abort(.notFound)
+        }
+        try await tax.delete(on: req.db)
+        return .noContent
+    }
+}

--- a/Sources/App/Migrations/CreateTax.swift
+++ b/Sources/App/Migrations/CreateTax.swift
@@ -1,0 +1,16 @@
+import Fluent
+
+struct CreateTax: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("taxes")
+            .id()
+            .field("name", .string, .required)
+            .field("rate", .double, .required)
+            .field("created_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("taxes").delete()
+    }
+}

--- a/Sources/App/Models/Tax.swift
+++ b/Sources/App/Models/Tax.swift
@@ -1,0 +1,27 @@
+import Fluent
+import Vapor
+
+final class Tax: Model, Content {
+    static let schema = "taxes"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "name")
+    var name: String
+
+    @Field(key: "rate")
+    var rate: Double
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    init() { }
+
+    init(id: UUID? = nil, name: String, rate: Double, createdAt: Date? = nil) {
+        self.id = id
+        self.name = name
+        self.rate = rate
+        self.createdAt = createdAt
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -1,7 +1,9 @@
 import Leaf
 import Vapor
+import Fluent
 
 public func configure(_ app: Application) async throws {
     app.views.use(.leaf)
+    app.migrations.add(CreateTax())
     try routes(app)
 }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,4 +1,5 @@
 import Vapor
+import Fluent
 
 func routes(_ app: Application) throws {
     app.get { req async throws in
@@ -17,4 +18,13 @@ func routes(_ app: Application) throws {
         return printHomeRole()
     }
 
+    let taxesController = TaxesController()
+    let taxes = app.grouped("taxes")
+    taxes.get(use: taxesController.index)
+    taxes.post(use: taxesController.create)
+    taxes.group(":taxID") { tax in
+        tax.get(use: taxesController.show)
+        tax.put(use: taxesController.update)
+        tax.delete(use: taxesController.delete)
+    }
 }


### PR DESCRIPTION
Fixes #1

Add CRUD operations for a new `taxes` table.

* **Model**: Add `Tax` model in `Sources/App/Models/Tax.swift` with properties `id`, `name`, `rate`, and `createdAt`.
* **Controller**: Add `TaxesController` in `Sources/App/Controllers/TaxesController.swift` with CRUD methods `index`, `create`, `show`, `update`, and `delete`.
* **Routes**: Modify `Sources/App/routes.swift` to include routes for `taxes` CRUD operations.
* **Migration**: Add `CreateTax` migration in `Sources/App/Migrations/CreateTax.swift` to create and drop the `taxes` table.
* **Configuration**: Modify `Sources/App/configure.swift` to register the `CreateTax` migration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zlovtnik/mue/pull/2?shareId=19ed13f4-add5-4d6c-afa4-70372330b561).